### PR TITLE
modify url

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "plotly-resampler" %}
-{% set version = "0.8.1" %}
+{% set version = "0.8.3" %}
 
 
 package:
@@ -7,8 +7,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/plotly-resampler-{{ version }}.tar.gz
-  sha256: 774940a64bf6e6d9fe0eafff42f12ca1f3df7a3603efbcfcea5ed901fdc6b35a
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/plotly_resampler-{{ version }}.tar.gz
+  sha256: d656986d458370ea9a3486042b00b942f32746b5ef173d55786b7a47910bd809
 
 build:
   number: 0
@@ -20,7 +20,7 @@ requirements:
     - numpy >=1.14
     - pip
     - poetry-core  # >=1.1.0a6
-    - python >=3.7.1,<3.11
+    - python >=3.7.1
   run:
     - dash >=2.2.0
     - flask-cors >=3.0.10
@@ -31,7 +31,7 @@ requirements:
     - orjson >=3.7.7
     - pandas >=1.3.5
     - plotly >=5.6.0
-    - python >=3.7.1,<3.11
+    - python >=3.7.1
     - trace-updater >=0.0.8
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
     - numpy >=1.14
     - pip
     - poetry-core  # >=1.1.0a6
-    - python >=3.7.1
+    - python >=3.7.1,<3.11
   run:
     - dash >=2.2.0
     - flask-cors >=3.0.10
@@ -31,7 +31,7 @@ requirements:
     - orjson >=3.7.7
     - pandas >=1.3.5
     - plotly >=5.6.0
-    - python >=3.7.1
+    - python >=3.7.1,<3.11
     - trace-updater >=0.0.8
 
 test:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
`plotly-resampler` has already updated to version `0.8.3` in [pypi](https://pypi.org/project/plotly-resampler/), but [conda-forge](https://anaconda.org/conda-forge/plotly-resampler) package still remains in version `0.8.1`.
According to the [update status](https://conda-forge.org/status/#version_updates) of conda-forge, the url link is broken.
![image](https://user-images.githubusercontent.com/5477995/215735588-8035bf90-486b-4585-9d23-3385dec04da7.png)

After some digging, I find out that the link https://pypi.io/packages/source/p/plotly-resampler/plotly-resampler-0.8.1.tar.gz is working while https://pypi.io/packages/source/p/plotly-resampler/plotly-resampler-0.8.2.tar.gz is not. However, the link https://pypi.io/packages/source/p/plotly-resampler/plotly_resampler-0.8.2.tar.gz and https://pypi.io/packages/source/p/plotly-resampler/plotly_resampler-0.8.3.tar.gz are working with change from "-" to "_".

I don't know what caused this behavior, and don't know whether it will persist.

<!--
Please add any other relevant info below:
-->
