### PR TITLE
Updating to 0.9.1 and removing old build attempts

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "plotly-resampler" %}
-{% set version = "0.8.3.2" %}
+{% set version = "0.9.1" %}
 
 
 package:
@@ -8,34 +8,30 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: 5cac870d6d269cdd71d28def4cae310c609c02aac636c0831176188f16021f44
+  sha256: 28d53709c8bfa8d0d4f85a0d969cbce2d2bfc00c376b8f932cd280360a5bb8cc
 
 build:
   number: 3
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
-  build:
-    - {{ compiler('c') }}
   host:
     - python
-    # at the time of writing
-    # numpy is globally pinned to 1.21 at build time
-    # and will export constraints that will require
-    # numpy 1.21 or greater at run time
     - numpy
     - pip
     - poetry-core >=1.1.0a6
   run:
-    - python
-    - dash >=2.2.0,<3.0.0
-    - flask-cors >=3.0.10,<4.0.0
-    - jupyter-dash >=0.4.2
-    - python-kaleido ==0.2.1
-    - orjson >=3.8.0,<4.0.0
-    - pandas >=1.3.5,<2.0.0
+    - python >=3.7.1,<4.0.0
     - plotly >=5.5.0,<6.0.0
+    - dash >=2.11.0,<3.0.0
+    - jupyter-dash >=0.4.2
+    - pandas >=1
+    - orjson >=3.8.0,<4.0.0
     - trace-updater >=0.0.8
+    - tsdownsample 0.1.2
+  run-constrained:
+    - python-kaleido ==0.2.1
+    - flask-cors >=3.0.10,<4.0.0
 
 test:
   imports:
@@ -50,7 +46,7 @@ test:
 about:
   home: https://github.com/predict-idlab/plotly-resampler
   doc_url: https://predict-idlab.github.io/plotly-resampler/
-  summary: Visualizing large time series with plotly
+  summary: Visualize large sequential data by adding resampling functionality to Plotly figures
   license: LicenseRef-plotly-resampler
   license_file: LICENSE
 
@@ -58,3 +54,4 @@ extra:
   recipe-maintainers:
     - jvdd
     - thewchan
+    - darynwhite


### PR DESCRIPTION
This should remove the need to build anything within this feedstock.

BUT it does require `tsdownsample` to have a feedstock as well. Which requires [this PR](https://github.com/conda-forge/staged-recipes/pull/23550?notification_referrer_id=NT_kwDOAmcAF7M3MjYyOTg4ODY5OjQwMzA0NjYz) to add `tsdownsample` to `conda-forge`

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
